### PR TITLE
Update erc20.cairo

### DIFF
--- a/starknet/exercises/contracts/erc20/erc20.cairo
+++ b/starknet/exercises/contracts/erc20/erc20.cairo
@@ -33,7 +33,7 @@ from exercises.contracts.erc20.ERC20_base import (
 func constructor{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}(
     name: felt, symbol: felt, initial_supply: Uint256, admin: felt
 ) {
-    ERC20_initializer(name, symbol, initial_supply, recipient);
+    ERC20_initializer(name, symbol, initial_supply, admin);
     admin.write(admin);
     return ();
 }

--- a/starknet/exercises/contracts/erc20/erc20.cairo
+++ b/starknet/exercises/contracts/erc20/erc20.cairo
@@ -31,10 +31,10 @@ from exercises.contracts.erc20.ERC20_base import (
 
 @constructor
 func constructor{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}(
-    name: felt, symbol: felt, initial_supply: Uint256, admin: felt
+    name: felt, symbol: felt, initial_supply: Uint256, recipient: felt
 ) {
-    ERC20_initializer(name, symbol, initial_supply, admin);
-    admin.write(admin);
+    ERC20_initializer(name, symbol, initial_supply, recipient);
+    admin.write(recipient);
     return ();
 }
 


### PR DESCRIPTION
MINT_ADMIN address is stored in **admin** variable while unknown scope variable **recipient**, is being passed to the ERC20_initializer.