### PR TITLE
Assert User's balance post burning tokens

### DIFF
--- a/starknet/test/test_erc20.cairo
+++ b/starknet/test/test_erc20.cairo
@@ -90,11 +90,25 @@ func test_burn_haircut{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_che
 
     // Get airdrop
     Erc20.faucet(contract_address=contract_address, amount=Uint256(666, 0));
+    
+    // Start user balance
+    let (start_user_balance) = Erc20.balanceOf(
+        contract_address=contract_address, account=TEST_ACC1
+    );
 
     // Call burn
     Erc20.burn(contract_address=contract_address, amount=Uint256(500, 0));
     %{ stop_prank_callable() %}
+    
+    // Final user balance
+    let (final_user_balance) = Erc20.balanceOf(
+        contract_address=contract_address, account=TEST_ACC1
+    );
 
+    // Assert user's balance decreased by 500
+    let (user_diff) = uint256_sub( start_user_balance, final_user_balance);
+    assert user_diff.low = 500;
+    
     // Final admin balance
     let (final_admin_balance) = Erc20.balanceOf(
         contract_address=contract_address, account=MINT_ADMIN


### PR DESCRIPTION
In the current scenario, the test cases to check burn() are passing ,  even without the user actually burning his tokens.

Example Scenario : -
   Suppose the user tries burning 500 tokens :
the test cases are passed just by transferring the 10% of burn amount (50 tokens) to admin.

Here although burn is called , effectively the balance of the user post burn should reduce by 500 tokens, but there is no check being done to validate whether the user balance is actually decreased by the desired amount post calling the burn method.